### PR TITLE
Flexible cache url params

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ type Configuration struct {
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
 	CacheHost       string             `mapstructure:"prebid_cache_host"`
-	CacheMacro		string             `mapstructure:"prebid_cache_macros"`
+	CacheMacro      string             `mapstructure:"prebid_cache_macros"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,8 @@ type Configuration struct {
 	Port            int                `mapstructure:"port"`
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
-	CacheURL        string             `mapstructure:"prebid_cache_url"`
+	CacheHost       string             `mapstructure:"prebid_cache_host"`
+	CacheMacro		string             `mapstructure:"prebid_cache_macros"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`

--- a/config/config.go
+++ b/config/config.go
@@ -11,8 +11,8 @@ type Configuration struct {
 	Port            int                `mapstructure:"port"`
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
-	CacheHost       string             `mapstructure:"prebid_cache_host"`
-	CacheMacro      string             `mapstructure:"prebid_cache_macros"`
+	CacheUrl        string             `mapstructure:"prebid_cache_url"`
+	Macros          string             `mapstructure:"prebid_cache_macros"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ type Configuration struct {
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
 	CacheUrl        string             `mapstructure:"prebid_cache_url"`
-	Macros          string             `mapstructure:"prebid_cache_macros"`
+	Macros          string             `mapstructure:"macros"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -66,7 +66,7 @@ host: prebid-server.prebid.org
 port: 1234
 admin_port: 5678
 default_timeout_ms: 123
-prebid_cache_host: http://prebidcache.net
+prebid_cache_url: http://prebidcache.net
 prebid_cache_macros: uuid=%PBS_CACHE_UUID%
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
@@ -129,8 +129,8 @@ func TestFullConfig(t *testing.T) {
 	if cfg.DefaultTimeout != 123 {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
-	cmpStrings(t, "prebid_cache_host", cfg.CacheHost, "http://prebidcache.net")
-	cmpStrings(t, "prebid_cache_macros", cfg.CacheMacro, "uuid=%PBS_CACHE_UUID%")
+	cmpStrings(t, "prebid_cache_url", cfg.CacheUrl, "http://prebidcache.net")
+	cmpStrings(t, "prebid_cache_macros", cfg.Macros, "uuid=%PBS_CACHE_UUID%")
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
 	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -66,7 +66,8 @@ host: prebid-server.prebid.org
 port: 1234
 admin_port: 5678
 default_timeout_ms: 123
-prebid_cache_url: http://prebidcache.net/test/a1?qs=something
+prebid_cache_host: http://prebidcache.net
+prebid_cache_macros: uuid=%PBS_CACHE_UUID%
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
   host: upstream:8232
@@ -128,7 +129,8 @@ func TestFullConfig(t *testing.T) {
 	if cfg.DefaultTimeout != 123 {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
-	cmpStrings(t, "prebid_cache_url", cfg.CacheURL, "http://prebidcache.net/test/a1?qs=something")
+	cmpStrings(t, "prebid_cache_host", cfg.CacheHost, "http://prebidcache.net")
+	cmpStrings(t, "prebid_cache_macros", cfg.CacheMacro, "uuid=%PBS_CACHE_UUID%")
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
 	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -67,7 +67,7 @@ port: 1234
 admin_port: 5678
 default_timeout_ms: 123
 prebid_cache_url: http://prebidcache.net
-prebid_cache_macros: uuid=%PBS_CACHE_UUID%
+macros: uuid=%PBS_CACHE_UUID%
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
   host: upstream:8232
@@ -130,7 +130,7 @@ func TestFullConfig(t *testing.T) {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
 	cmpStrings(t, "prebid_cache_url", cfg.CacheUrl, "http://prebidcache.net")
-	cmpStrings(t, "prebid_cache_macros", cfg.Macros, "uuid=%PBS_CACHE_UUID%")
+	cmpStrings(t, "macros", cfg.Macros, "uuid=%PBS_CACHE_UUID%")
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
 	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")

--- a/pbs/pbsresponse.go
+++ b/pbs/pbsresponse.go
@@ -41,6 +41,9 @@ type PBSBid struct {
 	// CacheId is an ID in prebid-cache which can be used to fetch this ad's content.
 	// This supports prebid-mobile, which requires that the content be available from a URL.
 	CacheID string `json:"cache_id,omitempty"`
+	// Complete cache url returned from the prebid-cache.
+	// more flexible than a design that assumes the UUID is always appended to the end of the URL.
+	CacheUrl string `json:"cache_url,omitempty"`
 	// ResponseTime is the number of milliseconds it took for the adapter to return a bid.
 	ResponseTime      int               `json:"response_time_ms,omitempty"`
 	AdServerTargeting map[string]string `json:"ad_server_targeting,omitempty"`

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -313,7 +313,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 		}
 		for i, bid := range pbs_resp.Bids {
 			bid.CacheID = cobjs[i].UUID
-			bid.CacheUrl = deps.cfg.CacheHost + "/cache?" + strings.Replace(deps.cfg.CacheMacro, "%PBS_CACHE_UUID%", bid.CacheID, 1);
+			bid.CacheUrl = deps.cfg.CacheUrl + "/cache?" + strings.Replace(deps.cfg.Macros, "%PBS_CACHE_UUID%", bid.CacheID, 1);
 			bid.NURL = ""
 			bid.Adm = ""
 		}
@@ -714,7 +714,7 @@ func serve(cfg *config.Configuration) error {
 	router.POST("/optout", userSyncDeps.OptOut)
 	router.GET("/optout", userSyncDeps.OptOut)
 
-	pbc.InitPrebidCache(cfg.CacheHost)
+	pbc.InitPrebidCache(cfg.CacheUrl)
 
 	// Add CORS middleware
 	c := cors.New(cors.Options{AllowCredentials: true})

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -36,6 +36,7 @@ import (
 	"github.com/prebid/prebid-server/pbsmetrics"
 	"github.com/prebid/prebid-server/prebid"
 	pbc "github.com/prebid/prebid-server/prebid_cache_client"
+	"strings"
 )
 
 var hostCookieSettings pbs.HostCookieSettings
@@ -154,7 +155,8 @@ func (deps *cookieSyncDeps) cookieSync(w http.ResponseWriter, r *http.Request, _
 }
 
 type auctionDeps struct {
-	m *pbsmetrics.Metrics
+	m   *pbsmetrics.Metrics
+	cfg *config.Configuration
 }
 
 func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -311,6 +313,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 		}
 		for i, bid := range pbs_resp.Bids {
 			bid.CacheID = cobjs[i].UUID
+			bid.CacheUrl = deps.cfg.CacheHost + "/cache?" + strings.Replace(deps.cfg.CacheMacro, "%PBS_CACHE_UUID%", bid.CacheID, 1);
 			bid.NURL = ""
 			bid.Adm = ""
 		}
@@ -682,7 +685,7 @@ func serve(cfg *config.Configuration) error {
 	})()
 
 	router := httprouter.New()
-	router.POST("/auction", (&auctionDeps{m}).auction)
+	router.POST("/auction", (&auctionDeps{m, cfg}).auction)
 	router.GET("/bidders/params", NewJsonDirectoryServer(schemaDirectory))
 	router.POST("/cookie_sync", (&cookieSyncDeps{m}).cookieSync)
 	router.POST("/validate", validate)
@@ -711,7 +714,7 @@ func serve(cfg *config.Configuration) error {
 	router.POST("/optout", userSyncDeps.OptOut)
 	router.GET("/optout", userSyncDeps.OptOut)
 
-	pbc.InitPrebidCache(cfg.CacheURL)
+	pbc.InitPrebidCache(cfg.CacheHost)
 
 	// Add CORS middleware
 	c := cors.New(cors.Options{AllowCredentials: true})


### PR DESCRIPTION
In addition to the cache_id, Prebid Server returns the whole cached asset URL to the client. i.e. in addition to
`"cache_id":"e3cb28fd-0eff-43a9-af62-d118b5453a20"` 
it also sends
`"cache_url": "https://mycachedomain.com/cache?uuid=e3cb28fd-0eff-43a9-af62-d118b5453a20"`

The server config takes a new parameter defining the URL pattern. e.g.
`"client_asset_url": "https://mycachedomain.com/cache?uuid=PBS_CACHE_UUID"`
 Prebid server would resolve PBS_CACHE_UUID to the UUID returned by the cache server.

Note: this design is more flexible than a design that assumes the UUID is always appended to the end of the URL