### PR TITLE
Built scalable structure for cache in config and moved cache url form…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ type Configuration struct {
 	Port            int                `mapstructure:"port"`
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
-	CacheUrl        Cache              `mapstructure:"cache"`
+	CacheURL        Cache              `mapstructure:"cache"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`
@@ -72,10 +72,10 @@ func New() (*Configuration, error) {
 	return &c, nil
 }
 
-func (cfg *Configuration) GetCacheUrl(uuid string) string {
+func (cfg *Configuration) GetCacheURL(uuid string) string {
 	var buffer bytes.Buffer
-	buffer.WriteString(cfg.CacheUrl.Host)
+	buffer.WriteString(cfg.CacheURL.Host)
 	buffer.WriteString("/cache?")
-	buffer.WriteString(strings.Replace(cfg.CacheUrl.Query, "%PBS_CACHE_UUID%", uuid, 1))
+	buffer.WriteString(strings.Replace(cfg.CacheURL.Query, "%PBS_CACHE_UUID%", uuid, 1))
 	return buffer.String()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bytes"
 	"github.com/spf13/viper"
+	"strings"
 )
 
 // Configuration
@@ -11,8 +13,7 @@ type Configuration struct {
 	Port            int                `mapstructure:"port"`
 	AdminPort       int                `mapstructure:"admin_port"`
 	DefaultTimeout  uint64             `mapstructure:"default_timeout_ms"`
-	CacheUrl        string             `mapstructure:"prebid_cache_url"`
-	Macros          string             `mapstructure:"macros"`
+	CacheUrl        Cache              `mapstructure:"cache"`
 	RecaptchaSecret string             `mapstructure:"recaptcha_secret"`
 	HostCookie      HostCookie         `mapstructure:"host_cookie"`
 	Metrics         Metrics            `mapstructure:"metrics"`
@@ -57,6 +58,11 @@ type DataCache struct {
 	TTLSeconds int    `mapstructure:"ttl_seconds"`
 }
 
+type Cache struct {
+	Host  string `mapstructure:"host"`
+	Query string `mapstructure:"query"`
+}
+
 // New uses viper to get our server configurations
 func New() (*Configuration, error) {
 	var c Configuration
@@ -64,4 +70,12 @@ func New() (*Configuration, error) {
 		return nil, err
 	}
 	return &c, nil
+}
+
+func (cfg *Configuration) GetCacheUrl(uuid string) string {
+	var buffer bytes.Buffer
+	buffer.WriteString(cfg.CacheUrl.Host)
+	buffer.WriteString("/cache?")
+	buffer.WriteString(strings.Replace(cfg.CacheUrl.Query, "%PBS_CACHE_UUID%", uuid, 1))
+	return buffer.String()
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -66,8 +66,9 @@ host: prebid-server.prebid.org
 port: 1234
 admin_port: 5678
 default_timeout_ms: 123
-prebid_cache_url: http://prebidcache.net
-macros: uuid=%PBS_CACHE_UUID%
+cache:
+  host: http://prebidcache.net
+  query: uuid=%PBS_CACHE_UUID%
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
   host: upstream:8232
@@ -129,8 +130,8 @@ func TestFullConfig(t *testing.T) {
 	if cfg.DefaultTimeout != 123 {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
-	cmpStrings(t, "prebid_cache_url", cfg.CacheUrl, "http://prebidcache.net")
-	cmpStrings(t, "macros", cfg.Macros, "uuid=%PBS_CACHE_UUID%")
+	cmpStrings(t, "cache.host", cfg.CacheUrl.Host, "http://prebidcache.net")
+	cmpStrings(t, "cache.query", cfg.CacheUrl.Query, "uuid=%PBS_CACHE_UUID%")
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
 	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -130,8 +130,8 @@ func TestFullConfig(t *testing.T) {
 	if cfg.DefaultTimeout != 123 {
 		t.Errorf("DefaultTimeout was %d not 123", cfg.DefaultTimeout)
 	}
-	cmpStrings(t, "cache.host", cfg.CacheUrl.Host, "http://prebidcache.net")
-	cmpStrings(t, "cache.query", cfg.CacheUrl.Query, "uuid=%PBS_CACHE_UUID%")
+	cmpStrings(t, "cache.host", cfg.CacheURL.Host, "http://prebidcache.net")
+	cmpStrings(t, "cache.query", cfg.CacheURL.Query, "uuid=%PBS_CACHE_UUID%")
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
 	cmpStrings(t, "metrics.host", cfg.Metrics.Host, "upstream:8232")
 	cmpStrings(t, "metrics.database", cfg.Metrics.Database, "metricsdb")

--- a/pbs/pbsresponse.go
+++ b/pbs/pbsresponse.go
@@ -43,7 +43,7 @@ type PBSBid struct {
 	CacheID string `json:"cache_id,omitempty"`
 	// Complete cache url returned from the prebid-cache.
 	// more flexible than a design that assumes the UUID is always appended to the end of the URL.
-	CacheUrl string `json:"cache_url,omitempty"`
+	CacheURL string `json:"cache_url,omitempty"`
 	// ResponseTime is the number of milliseconds it took for the adapter to return a bid.
 	ResponseTime      int               `json:"response_time_ms,omitempty"`
 	AdServerTargeting map[string]string `json:"ad_server_targeting,omitempty"`

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -312,7 +312,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 		}
 		for i, bid := range pbs_resp.Bids {
 			bid.CacheID = cobjs[i].UUID
-			bid.CacheUrl = deps.cfg.GetCacheUrl(bid.CacheID)
+			bid.CacheURL = deps.cfg.GetCacheURL(bid.CacheID)
 			bid.NURL = ""
 			bid.Adm = ""
 		}
@@ -713,7 +713,7 @@ func serve(cfg *config.Configuration) error {
 	router.POST("/optout", userSyncDeps.OptOut)
 	router.GET("/optout", userSyncDeps.OptOut)
 
-	pbc.InitPrebidCache(cfg.CacheUrl.Host)
+	pbc.InitPrebidCache(cfg.CacheURL.Host)
 
 	// Add CORS middleware
 	c := cors.New(cors.Options{AllowCredentials: true})

--- a/pbs_light.go
+++ b/pbs_light.go
@@ -36,7 +36,6 @@ import (
 	"github.com/prebid/prebid-server/pbsmetrics"
 	"github.com/prebid/prebid-server/prebid"
 	pbc "github.com/prebid/prebid-server/prebid_cache_client"
-	"strings"
 )
 
 var hostCookieSettings pbs.HostCookieSettings
@@ -313,7 +312,7 @@ func (deps *auctionDeps) auction(w http.ResponseWriter, r *http.Request, _ httpr
 		}
 		for i, bid := range pbs_resp.Bids {
 			bid.CacheID = cobjs[i].UUID
-			bid.CacheUrl = deps.cfg.CacheUrl + "/cache?" + strings.Replace(deps.cfg.Macros, "%PBS_CACHE_UUID%", bid.CacheID, 1)
+			bid.CacheUrl = deps.cfg.GetCacheUrl(bid.CacheID)
 			bid.NURL = ""
 			bid.Adm = ""
 		}
@@ -714,7 +713,7 @@ func serve(cfg *config.Configuration) error {
 	router.POST("/optout", userSyncDeps.OptOut)
 	router.GET("/optout", userSyncDeps.OptOut)
 
-	pbc.InitPrebidCache(cfg.CacheUrl)
+	pbc.InitPrebidCache(cfg.CacheUrl.Host)
 
 	// Add CORS middleware
 	c := cors.New(cors.Options{AllowCredentials: true})


### PR DESCRIPTION
Addressed the following requested changes:
1. consolidate the "cache configs" in a struct to help keep the config organized, and we'll have a scalable structure if people want to add config options for the scheme, port, etc, later.
2. String concatenation could be very inefficient, since each string concatenation makes a new string & copies the old one - so used bytes.buffer to optimize.
3. Move cache url formation into a function in config module.